### PR TITLE
rollback gem name due there is not gem structure change

### DIFF
--- a/cutest.gemspec
+++ b/cutest.gemspec
@@ -1,7 +1,7 @@
 require "./lib/cutest"
 
 Gem::Specification.new do |s|
-  s.name              = "cutest-cj"
+  s.name              = "cutest"
   s.version           = Cutest::VERSION
   s.summary           = "Forking tests."
   s.description       = "Run tests in separate processes to avoid shared state."


### PR DESCRIPTION
## Why? 

rollback gem name due there is not gem structure change that followed up the conventions, customize a gem does not mean to rename it all. We can rename it but we should follow conventions.

This also prevents names collision and issues in our projects